### PR TITLE
Removes "Smartmatch is experimental" warning

### DIFF
--- a/backup-tools/duplicity/duplicityBackup
+++ b/backup-tools/duplicity/duplicityBackup
@@ -28,6 +28,7 @@
 use 5.010;
 
 ##### Modules #####
+use experimental 'smartmatch'; # Debian package "libexperimental-perl"
 use Switch;
 use List::Util qw(max reduce);
 use Hash::Merge::Simple qw/ merge /; # Debian package "libhash-merge-simple-perl"


### PR DESCRIPTION
This commit fixes the "Smartmatch is experimental" warnings with Perl 5.18 and above by using [experimental](https://metacpan.org/module/experimental) CPAN module.

Fixes: #13
